### PR TITLE
Added the logic for the power_exp in the operator precedence.

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -1,22 +1,31 @@
 <program> ::= { <declaration> }
+
 <declaration> ::= <variable_declaration> 
                 | <array_declaration> 
                 | <function_declaration> 
 
 <variable_declaration> ::= <data_type> <identifier> "=" <exp>  { "," <identifier> "=" <exp> } ";" 
-                        | <data_type> <identifier> { "," <identifier> } ";" 
-<array_declaration> ::= <data_type> <identifier> "[" [<const>]  "]"  [ "=" "{" <argument_list>"}" ] ";"
-<function_declaration> ::= <data_type> <identifier> "(" <parameter_list> ")" ( <block> | ";" )
+                                      | <data_type> <identifier> { “,” <identifier> } “;” 
 
-<parameter_list> ::= ["void"] | <data_type> <identifier> {"," <data_type> <identifier>}
+<array_declaration> ::= <data_type> <identifier> “[“ [<const>]  “]”  [ “=” “{“ <argument_list>“}” ] “;”
+
+<function_declaration> ::= <data_type> <identifier> "(" <parameter_list> ")" ( <block> | “;” )
+
+<parameter_list> ::= [“void”]
+                                | <data_type> <identifier> {"," <data_type> <identifier>}
+
 <argument_list> ::= <exp> { "," <exp> }
 
-<data_type> ::= "int" | "float" | "char" | "bool"
+<data_type> ::= “int” | “float” | “char” | “bool”
 
-<block> ::= "{" <block-item-list>  "}"
+<block> ::= "{" <block_item_list>  "}"
 <block_item_list> ::= <block_item_list> <block_item>
                                 | <block_item>
+
 <block_item> ::= <statement> | <variable_declaration> | <array_declaration> 
+
+
+
 <statement> ::= "return" <exp> ";"
               | <exp> ";"
               | ";"
@@ -27,28 +36,53 @@
               | <input_statement> 
               | <output_statement>
 
+
 <for_statement> ::= "for" "(" (<variable_declaration> | <array_declaration> | <exp> ";") <exp> ";" <exp> ")" <block>    
+
 <while_statement> ::= "while" "(" <exp> ")" <block>
+
 <input_statement> ::= "scanf" "(" <string> { "," "&" <identifier> } ")" ";"
-<output_statement> ::= "printf" "(" <string> ")" ";" 
-                                    | "printf" "(" <string> "," <exp> ")" ";"
+
+<output_statement> ::= "printf" "(" <string> ")"  ";"
+                                    | "printf" "(" <string> “,” <exp> ")" ";"
                                     | "printf" "(" <string> { "," <exp> } ")" ";"
                                     | "printf" "(" <identifier> ")" ";"
+
+
 <if_statement> ::= "if" "(" <exp> ")" <block> [<else-clause>]
 <else-clause> ::= "else" <block>
                            | "else" <if_statement>
               
-<exp> ::= <logical_or_exp> | (<identifier> | <identifier> "[" <const> "]" ) "=" <exp>  
-<logical_or_exp> ::= <logical_and_exp> | <logical_or_exp>  "||" <logical_and_exp> 
-<logical_and_exp> ::= <equality_exp> | <logical_and_exp>  "&&" <equality_exp> 
-<equality_exp> ::= <relational_exp> | <equality_exp>  ("==" | "!=") <relational_exp> 
-<relational_exp> ::= <additive_exp> | <relational_exp> ("<" | ">" | "<=" | ">=") <additive_exp> 
-<additive_exp> ::= <multiplicative_exp> | <additive_exp> ("+" | "-") <multiplicative_exp> 
-<multiplicative_exp> ::= <power_exp> | <multiplicative_exp> ("*" | "/" | "%") <power_exp>
-<power_exp> ::= <unary_exp> | <unary_exp> "^" <power_exp> 
+<exp> ::= <logical_or_exp> 
+               | (<identifier> | <identifier> "[" <const> "]" ) "=" <exp>  
+
+<logical_or_exp> ::= <logical_and_exp>
+                                | <logical_or_exp>  "||" <logical_and_exp> 
+
+<logical_and_exp> ::= <equality_exp> 
+                                   | <logical_and_exp>  "&&" <equality_exp> 
+
+<equality_exp> ::= <relational_exp> 
+                             | <equality_exp>  ("==" | "!=") <relational_exp> 
+
+
+<relational_exp> ::= <additive_exp> 
+                                | <relational_exp> ("<" | ">" | "<=" | ">=") <additive_exp> 
+
+<additive_exp> ::= <multiplicative_exp> 
+                             | <additive_exp> ("+" | "-") <multiplicative_exp> 
+
+<multiplicative_exp> ::= <power_exp> 
+                                     | <multiplicative_exp> ("*" | "/" | "%") <power_exp>
+
+<power_exp> ::= <unary_exp> 
+                         | <unary_exp> ”^” <power_exp> 
+
 <unary_exp> ::= <factor> 
-                | <unop> <unary_exp>
-<unop> ::= "!" | "+" | "-" 
+                         | <unop> <unary_exp>
+
+<unop> ::= "!" | "+" | "-"
+
 <factor> ::= <const>
                  | <identifier>
                  | "(" <exp> ")"
@@ -56,9 +90,16 @@
                  | <identifier> "[" <const> "]" 
 
 <const> ::= <int> | <float> | <char> | <bool>
-<string> ::= STRING
-<identifier> ::= IDENTIFIER
-<int> ::= INTEGER_LITERAL
-<float> ::= FLOAT_LITERAL
-<char> ::= CHARACTER_LITERAL
-<bool> ::= "true" | "false"
+
+<string> ::= “string”
+
+<identifier> ::= “identifier”
+
+<int> ::= “integer_literal”
+
+<float> ::= “float_literal”
+
+<char> ::= “character_literal”
+
+<bool> ::= “true” | “false”
+


### PR DESCRIPTION
Added the logic for the exponent in the operator precedence.

**Grammar Update:**

The EBNF grammar has been extended to include the `power_exp` rule:

`
<power_exp> ::= <unary_exp> | <unary_exp> "^" <power_exp>
`

For an expression like a ^ b ^ c ^ d, it should be parsed as (a ^ (b ^ (c ^ d))) because the exponent operator is right-associative. This means that the exponentiation is performed from right to left, reflecting the correct order of operations.

To implement exponentiation with right-left associativity, the following changes were made:

`
// <power_exp> ::= <unary_exp> | <unary_exp> ”^” <power_exp>
ParseTreeNode *parse_power_exp() {

    // Start with the left operand (<unary_exp>)
    ParseTreeNode *left = parse_factor(); 

    // Check if there's a "^" operator.
    if (current_token < num_tokens && tokens[current_token].type == EXPONENT) {
        // Create the power expression node
        ParseTreeNode *node = create_power_exp_node();
        add_child(node, left);
       
       match_and_create_node(EXPONENT, "Exponent");  //match the '^'
       ParseTreeNode *right = parse_power_exp(); // Recurse on right side to get the expression
       add_child(node, right);

        return node;
    }

    // Return the left operand directly if there's no "^"
    return left;
}
`

This implementation ensures that the exponentiation is handled with the correct right-left associativity, and can also function if there are nested exponent operations. 

Kindly double check if the logic and ping me if anythings is amiss, thank you ^^