### PR TITLE
Added the logic for the unary_expressions 

### DIFF
--- a/implemented_grammar.ebnf
+++ b/implemented_grammar.ebnf
@@ -40,7 +40,8 @@
 <exp> ::= <logical_or_exp> | (<identifier> | <identifier> "[" <const> "]" ) "=" <exp>  
 <logical_or_exp> ::= <logical_and_exp> | <logical_or_exp>  "||" <logical_and_exp> 
 <logical_and_exp> ::= <power_exp> | <logical_and_exp>  "&&" <power_exp>
-<power_exp> ::= <factor> | <factor> "^" <power_exp> 
+<power_exp> ::= <unary_exp> | <unary_exp> "^" <power_exp> 
+<unary_exp> ::= <factor> | <unop><unary_exp>
 <factor> ::= <const>
             | <identifier>
             | "(" <exp> ")"

--- a/parser.c
+++ b/parser.c
@@ -1278,6 +1278,10 @@ ParseTreeNode *create_power_exp_node(){
     return create_node("Exponent");
 }
 
+ParseTreeNode *create_unary_exp_node(){
+    return create_node("Unary_Exp");
+}
+
 ParseTreeNode *create_factor_node()
 {
     return create_node("Factor");

--- a/test_parse.core
+++ b/test_parse.core
@@ -100,10 +100,11 @@ int main() {
         a = b = c = d = e = 10;
         a = b = (c = 2);
 
-    // Power exp statements 
-    b = a ^ c;
-    a = a ^ b ^ c; 
-    c = (a ^ b) ^ c;
+    // Unary exp 
+
+    b = -1;
+    c = ----3;
+    b = -3 ^ -5;
 
 }
 

--- a/test_parse.core
+++ b/test_parse.core
@@ -100,6 +100,11 @@ int main() {
         a = b = c = d = e = 10;
         a = b = (c = 2);
 
+    // Power exp statements 
+    b = a ^ c;
+    a = a ^ b ^ c; 
+    c = (a ^ b) ^ c;
+
 }
 
 


### PR DESCRIPTION
This introduces the logic for the parsing of unary expressions in the grammar. 

```
<unary_exp> ::= <factor> | <unop><unary_exp>
```

Here is the implemented logic 

```
// <unary_exp> ::= <factor> | <unop> <unary_exp>
ParseTreeNode *parse_unary_exp() {
    ParseTreeNode *node = create_node("Unary_Exp");

    // Check if the current token is a unary operator
    if (current_token < num_tokens && 
        (tokens[current_token].type == plus || 
         tokens[current_token].type == minus || 
         tokens[current_token].type == not)) {
        
        // Create a node for the unary operator
        ParseTreeNode *unary_op_node = match_and_create_node(tokens[current_token].type, "Unary_Op");
        add_child(node, unary_op_node);

        // Parse the operand (which is another unary expression)
        ParseTreeNode *operand = parse_unary_exp();
        add_child(node, operand);

    } else {
        // If there's no unary operator, just parse the factor
        ParseTreeNode *factor = parse_factor();
        add_child(node, factor);
    }

    return node;
}
```

- It creates an AST node for the unary expression.
- If a unary operator (+, -, or !) is found, it creates a node for the operator and recursively parses the operand (allowing nested unary expressions like ----3).
- If no unary operator is present, it parses a factor (e.g., a constant, identifier, or parenthesized expression).

This implementation ensures proper parsing of unary operations and aligns with the updated grammar rules.


Kindly double check pls if this works especially in according with the additive exp, thank uu ^^